### PR TITLE
test

### DIFF
--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -101,6 +101,7 @@ solana_rbpf = { workspace = true }
 
 [dev-dependencies]
 solana-ledger = { workspace = true }
+solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/sbf/rust/invoke/src/processor.rs
+++ b/programs/sbf/rust/invoke/src/processor.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "program")]
 #![allow(unreachable_code)]
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use {
     crate::instructions::*,

--- a/programs/sbf/rust/invoke/src/processor.rs
+++ b/programs/sbf/rust/invoke/src/processor.rs
@@ -798,6 +798,7 @@ fn process_instruction(
             let serialized_len_ptr =
                 unsafe { account.data.borrow_mut().as_mut_ptr().offset(-8) as *mut u64 };
             unsafe {
+                #[cfg_attr(nightly, allow(invalid_reference_casting))]
                 std::ptr::write(
                     &account.data as *const _ as usize as *mut Rc<RefCell<&mut [u8]>>,
                     Rc::from_raw(((rc_box_addr as usize) + mem::size_of::<usize>() * 2) as *mut _),
@@ -836,6 +837,7 @@ fn process_instruction(
             // global_deallocator.dealloc(rc_box_addr) which is invalid and
             // happens to write a poison value into the account.
             unsafe {
+                #[cfg_attr(nightly, allow(invalid_reference_casting))]
                 std::ptr::write(
                     &account.data as *const _ as usize as *mut Rc<RefCell<&mut [u8]>>,
                     Rc::new(RefCell::new(&mut [])),
@@ -886,6 +888,7 @@ fn process_instruction(
             // allows us to test having CallerAccount::ref_to_len_in_vm in an
             // account region.
             unsafe {
+                #[cfg_attr(nightly, allow(invalid_reference_casting))]
                 std::ptr::write(
                     &account.data as *const _ as usize as *mut Rc<RefCell<&mut [u8]>>,
                     Rc::from_raw(((rc_box_addr as usize) + mem::size_of::<usize>() * 2) as *mut _),
@@ -920,6 +923,7 @@ fn process_instruction(
             // global_deallocator.dealloc(rc_box_addr) which is invalid and
             // happens to write a poison value into the account.
             unsafe {
+                #[cfg_attr(nightly, allow(invalid_reference_casting))]
                 std::ptr::write(
                     &account.data as *const _ as usize as *mut Rc<RefCell<&mut [u8]>>,
                     Rc::new(RefCell::new(&mut [])),
@@ -1133,6 +1137,7 @@ fn process_instruction(
             let account = &accounts[ARGUMENT_INDEX];
             let key = *account.key;
             let key = &key as *const _ as usize;
+            #[cfg_attr(nightly, allow(invalid_reference_casting))]
             unsafe {
                 *mem::transmute::<_, *mut *const Pubkey>(&account.key) = key as *const Pubkey;
             }
@@ -1179,6 +1184,7 @@ fn process_instruction(
             const CALLEE_PROGRAM_INDEX: usize = 2;
             let account = &accounts[ARGUMENT_INDEX];
             let owner = account.owner as *const _ as usize + 1;
+            #[cfg_attr(nightly, allow(invalid_reference_casting))]
             unsafe {
                 *mem::transmute::<_, *mut *const Pubkey>(&account.owner) = owner as *const Pubkey;
             }

--- a/programs/sbf/rust/realloc/src/processor.rs
+++ b/programs/sbf/rust/realloc/src/processor.rs
@@ -1,7 +1,7 @@
 //! Example Rust-based SBF realloc test program
 
 #![cfg(feature = "program")]
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 
 extern crate solana_program;
 use {


### PR DESCRIPTION
#### pwobwem


#### summawy of changes


f-fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->

## Summary by Sourcery

Add nightly-specific compiler attribute to suppress reference casting warnings in Solana SBF Rust programs

Enhancements:
- Add cfg_attr annotations to suppress invalid reference casting warnings specifically for nightly Rust compiler

Build:
- Update Cargo.toml to include dev-context-only-utils feature for solana-sdk